### PR TITLE
fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ Adding a standard test case is easy.
 
 It will be picked up automatically when you run the tests.
 
-- See also: [Standard Tests Development Guide](betterproto/tests/README.md)
+- See also: [Standard Tests Development Guide](tests/README.md)
 
 #### Custom tests
 


### PR DESCRIPTION
Fix the link in README, it was going to a [unknown page](https://github.com/danielgtaylor/python-betterproto/blob/master/betterproto/tests/README.md) with a 404 error.
